### PR TITLE
Add C-backed histogram for raw and JPEG preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.raw
 *.json
 img2snd
+
+*.so

--- a/GugusseGUI.py
+++ b/GugusseGUI.py
@@ -1,7 +1,9 @@
 import sys
 import json
+import numpy as np
+from Histogram import HistogramWidget, HistogramCalculator
 from PyQt5.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QHBoxLayout, QWidget, QLabel, QSlider, QComboBox, QPushButton, QLineEdit, QTextEdit, QSplitter, QSizePolicy, QWidget, QMessageBox
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 
 from TrinamicSilentMotor import MotorControlWidgets
 
@@ -173,7 +175,12 @@ class MainWindow(QMainWindow):
 
         # Text output area
         self.out.setReadOnly(True)
-        left_layout.addWidget(self.out)
+        self.histWidget = HistogramWidget(self)
+        self.logSplitter = QSplitter(Qt.Vertical)
+        self.logSplitter.addWidget(self.histWidget)
+        self.logSplitter.addWidget(self.out)
+        self.logSplitter.setSizes([1,1])
+        left_layout.addWidget(self.logSplitter)
         self.main_layout.addWidget(self.bottom_layout)
 
         # Camera preview area
@@ -193,6 +200,10 @@ class MainWindow(QMainWindow):
         self.sharpness.syncCamera()
         self.hflip.syncCamera() # syncing one syncs the other, and start cam
         self.picam2.start()
+        self.histcalc = HistogramCalculator()
+        self.histTimer = QTimer(self)
+        self.histTimer.timeout.connect(self.updateHistogram)
+        self.histTimer.start(500)
 
     def disableWidgetsWhenCapture(self):
         self.light_selector.setEnabled(False)
@@ -216,6 +227,21 @@ class MainWindow(QMainWindow):
 
     def getBottomLayout(self):
         return self.bottom_layout
+
+    def updateHistogram(self):
+        mode = self.captureMode.currentText()
+        try:
+            if mode == "DNG":
+                buf = self.picam2.capture_buffer("raw")
+                arr = np.frombuffer(buf, dtype=np.uint8)
+                hist = self.histcalc.hist_gray12(arr)
+                self.histWidget.setHistogram(hist, "gray12")
+            else:
+                arr = self.picam2.capture_array("main")
+                hist = self.histcalc.hist_rgb8(arr)
+                self.histWidget.setHistogram(hist, "rgb")
+        except Exception as e:
+            print(f"Histogram update error: {e}")
 
     def on_slider_value_changed(self, control, value):
         self.out.append(f'Slider value changed for control: {control} to {value}')

--- a/Histogram.py
+++ b/Histogram.py
@@ -1,0 +1,86 @@
+import os
+import subprocess
+import numpy as np
+from ctypes import CDLL, c_uint8, c_uint32, c_size_t, POINTER
+from PyQt5.QtWidgets import QWidget
+from PyQt5.QtGui import QPainter, QPen
+from PyQt5.QtCore import Qt
+
+class HistogramCalculator:
+    def __init__(self):
+        base = os.path.dirname(__file__)
+        self.lib_path = os.path.join(base, 'histogram.so')
+        if not os.path.exists(self.lib_path):
+            src = os.path.join(base, 'histogram.c')
+            subprocess.check_call(['gcc', '-O3', '-shared', '-fPIC', '-o', self.lib_path, src])
+        self.lib = CDLL(self.lib_path)
+        self.lib.histogram_rgb8.argtypes = [POINTER(c_uint8), c_size_t,
+                                            POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32)]
+        self.lib.histogram_gray12.argtypes = [POINTER(c_uint8), c_size_t,
+                                              POINTER(c_uint32)]
+
+    def hist_rgb8(self, arr):
+        h, w, _ = arr.shape
+        pixel_count = h * w
+        hist_r = np.zeros(256, dtype=np.uint32)
+        hist_g = np.zeros(256, dtype=np.uint32)
+        hist_b = np.zeros(256, dtype=np.uint32)
+        self.lib.histogram_rgb8(arr.ctypes.data_as(POINTER(c_uint8)), pixel_count,
+                                hist_r.ctypes.data_as(POINTER(c_uint32)),
+                                hist_g.ctypes.data_as(POINTER(c_uint32)),
+                                hist_b.ctypes.data_as(POINTER(c_uint32)))
+        return hist_r, hist_g, hist_b
+
+    def hist_gray12(self, data):
+        byte_count = data.size
+        hist = np.zeros(4096, dtype=np.uint32)
+        self.lib.histogram_gray12(data.ctypes.data_as(POINTER(c_uint8)), byte_count,
+                                  hist.ctypes.data_as(POINTER(c_uint32)))
+        return hist
+
+class HistogramWidget(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.mode = None
+        self.hist = None
+        self.setMinimumHeight(100)
+
+    def setHistogram(self, hist, mode):
+        self.mode = mode
+        if mode == 'gray12':
+            self.hist = hist.reshape(256, 16).sum(axis=1)
+        else:
+            self.hist = hist
+        self.update()
+
+    def paintEvent(self, event):
+        if self.hist is None:
+            return
+        painter = QPainter(self)
+        rect = self.rect()
+        painter.fillRect(rect, Qt.black)
+        width = rect.width()
+        height = rect.height()
+        if self.mode == 'rgb':
+            maxv = max(h.max() for h in self.hist)
+            if maxv == 0:
+                return
+            step = width / 256.0
+            colors = [Qt.red, Qt.green, Qt.blue]
+            for chan, color in zip(self.hist, colors):
+                pen = QPen(color)
+                painter.setPen(pen)
+                for i in range(256):
+                    v = chan[i] / maxv
+                    painter.drawLine(int(i * step), height, int(i * step), height - int(v * height))
+        else:
+            maxv = self.hist.max()
+            if maxv == 0:
+                return
+            bins = len(self.hist)
+            step = width / float(bins)
+            pen = QPen(Qt.white)
+            painter.setPen(pen)
+            for i in range(bins):
+                v = self.hist[i] / maxv
+                painter.drawLine(int(i * step), height, int(i * step), height - int(v * height))

--- a/histogram.c
+++ b/histogram.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+#include <stddef.h>
+
+void histogram_rgb8(const uint8_t *data, size_t pixel_count,
+                    uint32_t *hist_r, uint32_t *hist_g, uint32_t *hist_b) {
+    for (size_t i = 0; i < pixel_count; ++i) {
+        hist_r[data[3 * i]]++;
+        hist_g[data[3 * i + 1]]++;
+        hist_b[data[3 * i + 2]]++;
+    }
+}
+
+void histogram_gray12(const uint8_t *data, size_t byte_count, uint32_t *hist) {
+    size_t i = 0;
+    while (i + 2 < byte_count) {
+        uint16_t p0 = data[i] | ((data[i + 1] & 0x0F) << 8);
+        uint16_t p1 = (data[i + 1] >> 4) | (data[i + 2] << 4);
+        hist[p0]++;
+        hist[p1]++;
+        i += 3;
+    }
+}


### PR DESCRIPTION
## Summary
- Add C implementation to compute RGB and 12-bit grayscale histograms
- Provide Python wrapper and Qt widget to display histogram and compile C library on import
- Integrate histogram into GUI with timer updating from raw or preview frames
- Ignore compiled shared objects in git

## Testing
- `python -m py_compile Histogram.py GugusseGUI.py`
- `pip install numpy` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a16e47d8ac8325a30de3502ba2aa6b