### PR TITLE
Led motor heat reduction

### DIFF
--- a/CaptureLoop.py
+++ b/CaptureLoop.py
@@ -108,6 +108,13 @@ class CaptureLoop(QThread):
         self.win.motors["filmdrive"].motor.setFormat(currentFilmFormatCfg["filmdrive"], preserveSpeed=True)
         self.win.motors["pickup"].motor.setFormat(currentFilmFormatCfg["pickup"], preserveSpeed=True)
 
+        # histo/skipHisto/skipAdjust are left over from any previous run;
+        # without this a restart could recalculate speed off stale timings
+        # collected before the stop instead of waiting for fresh ones.
+        self.win.motors["feeder"].motor.resetSpeedAdaptation()
+        self.win.motors["filmdrive"].motor.resetSpeedAdaptation()
+        self.win.motors["pickup"].motor.resetSpeedAdaptation()
+
         self.win.motors["feeder"].motor.enable()
         self.win.motors["filmdrive"].motor.enable()
         self.win.motors["pickup"].motor.enable()

--- a/CaptureLoop.py
+++ b/CaptureLoop.py
@@ -137,6 +137,7 @@ class CaptureLoop(QThread):
                     sleep(0.1)
                 if timeout <= time():
                     self.signal.emit("timeout xfer error")
+                    self.signal.emit("turning lights off")
                     self.stopLoop()
         self.signal.emit("waiting up to 2 minutes for transfer queue to be cleared")
         timeout=time()+120
@@ -144,8 +145,9 @@ class CaptureLoop(QThread):
             sleep (0.1)
             if time() > timeout:
                 self.signal.emit("TIMEOUT waiting for end")
+                self.signal.emit("turning lights off")
                 break
-        
+
         self.signal.emit("stopping Export")
         self.export.stopLoop()        
         self.export.join()

--- a/CaptureLoop.py
+++ b/CaptureLoop.py
@@ -88,10 +88,14 @@ class CaptureLoop(QThread):
     def run(self):
         # send msgs
         self.signal.emit("Capture loop start")
+        # preserveSpeed=True: the "speed" field is edited/tuned by the operator
+        # and slowly recalculated live during a scan; a stop/restart must not
+        # wipe it back to the film format's default (only speed2 and the
+        # structural ramp parameters are reloaded here).
         currentFilmFormatCfg=self.win.hwSettings["filmFormats"][self.win.filmFormat.currentText()]
-        self.win.motors["feeder"].motor.setFormat(currentFilmFormatCfg["feeder"])
-        self.win.motors["filmdrive"].motor.setFormat(currentFilmFormatCfg["filmdrive"])
-        self.win.motors["pickup"].motor.setFormat(currentFilmFormatCfg["pickup"])
+        self.win.motors["feeder"].motor.setFormat(currentFilmFormatCfg["feeder"], preserveSpeed=True)
+        self.win.motors["filmdrive"].motor.setFormat(currentFilmFormatCfg["filmdrive"], preserveSpeed=True)
+        self.win.motors["pickup"].motor.setFormat(currentFilmFormatCfg["pickup"], preserveSpeed=True)
 
         self.win.motors["feeder"].motor.enable()
         self.win.motors["filmdrive"].motor.enable()
@@ -161,7 +165,10 @@ class RunStopWidget(QPushButton):
         self.win.filmFormat.setEnabled(state)
         self.win.projectName.setEnabled(state)
         self.win.captureMode.setEnabled(state)
-        self.win.light_selector.setEnabled(state)        
+        self.win.light_selector.setEnabled(state)
+        self.win.resetSpeeds.setEnabled(state)
+        for motor in self.win.speedEdits:
+            self.win.speedEdits[motor].setEnabled(state)
 
     def handlePush(self):
         if not self.running:

--- a/CaptureLoop.py
+++ b/CaptureLoop.py
@@ -70,8 +70,9 @@ class FrameSequence():
            self.signal.emit("turning lights off")
            raise Exception("Stop")
         skipReels=self.framesPerReelAdvance > 1 and self.frameCount % self.framesPerReelAdvance != 1
-        self.win.light_selector.lights.set("off")
-        self.win.light_selector.signal.emit("off")
+        if self.win.econolight.isChecked():
+            self.win.light_selector.lights.set("off")
+            self.win.light_selector.signal.emit("off")
         if not skipReels:
             m2.start()
             m3.start()

--- a/CaptureLoop.py
+++ b/CaptureLoop.py
@@ -56,6 +56,8 @@ class FrameSequence():
            self.signal.emit("sensors, wire disconnected...")
            self.signal.emit("---------------------------------------------")
            raise Exception("Capture stopped by Motor Faults!")
+        self.win.light_selector.lights.set("on")
+        self.win.light_selector.signal.emit("on")
         sleep(0.1)
         try:
            self.cam.captureCycle()
@@ -68,6 +70,8 @@ class FrameSequence():
            self.signal.emit("turning lights off")
            raise Exception("Stop")
         skipReels=self.framesPerReelAdvance > 1 and self.frameCount % self.framesPerReelAdvance != 1
+        self.win.light_selector.lights.set("off")
+        self.win.light_selector.signal.emit("off")
         if not skipReels:
             m2.start()
             m3.start()

--- a/CaptureLoop.py
+++ b/CaptureLoop.py
@@ -28,8 +28,12 @@ class FrameSequence():
         self.feeder.enable()
         self.pickup.enable()
         self.signal.emit("syncMotors")
+        currentFilmFormatCfg=self.win.hwSettings["filmFormats"][self.win.filmFormat.currentText()]
+        self.framesPerReelAdvance=currentFilmFormatCfg.get("framesPerReelAdvance", 1)
+        self.frameCount=0
                    
     def frameAdvance(self):
+        self.frameCount+=1
         m1=MotorThread(self.filmdrive)
         m2=MotorThread(self.feeder)
         m3=MotorThread(self.pickup)
@@ -63,10 +67,12 @@ class FrameSequence():
            self.signal.emit("syncMotors")
            self.signal.emit("turning lights off")
            raise Exception("Stop")
-        m2.start()
-        m3.start()
-        m3.join()
-        m2.join()
+        skipReels=self.framesPerReelAdvance > 1 and self.frameCount % self.framesPerReelAdvance != 1
+        if not skipReels:
+            m2.start()
+            m3.start()
+            m3.join()
+            m2.join()
         m1.start()
         m1.join()
 

--- a/CaptureSettings.py
+++ b/CaptureSettings.py
@@ -52,6 +52,14 @@ class FilmFormatWidget(QComboBox):
     def handle(self, text):
         self.win.out.append(f"film format changed to {text}")
         self.win.settings["FilmFormat"]=text
+        cfg=self.allFormats[text]
+        for motor in ["feeder", "filmdrive", "pickup"]:
+            m=self.win.motors[motor].motor
+            m.setFormat(cfg[motor])
+            editor=self.win.speedEdits[motor]
+            editor.blockSignals(True)
+            editor.setValue(m.speed)
+            editor.blockSignals(False)
 
     def getLabel(self):
         return self.label
@@ -127,3 +135,36 @@ class SaveSettingsWidget(QPushButton):
         self.win.settings.save()
         self.lastSaved=dict(self.win.settings)
         self.win.out.append("Settings saved.")
+
+
+class ResetSpeedsWidget(QPushButton):
+    def __init__(self, win):
+        QPushButton.__init__(self, "Reset Speeds")
+        self.win=win
+        self.clicked.connect(self.execute)
+
+    def execute(self):
+        # Note: hardwarecfg.json is never written to as a result of this -
+        # it only ever restores motor.speed in memory from what is already
+        # on disk (the operator edits the JSON by hand if defaults change).
+        cfg=self.win.hwSettings["filmFormats"][self.win.filmFormat.currentText()]
+        changed=False
+        for motor in ["feeder", "filmdrive", "pickup"]:
+            target=cfg[motor]["speed"]
+            m=self.win.motors[motor].motor
+            if int(m.speed) != int(target):
+                changed=True
+            if not m.setSpeed(target):
+                self.win.out.append(
+                    f"Reset Speeds: {motor} default speed {target} is outside "
+                    f"its {m.minSpeed}-{m.maxSpeed} hardware range, left unchanged."
+                )
+                continue
+            editor=self.win.speedEdits[motor]
+            editor.blockSignals(True)
+            editor.setValue(m.speed)
+            editor.blockSignals(False)
+        if changed:
+            self.win.out.append("Speeds reset to film format defaults.")
+        else:
+            self.win.out.append("Reset Speeds had no effect: speeds already at film format defaults.")

--- a/ConfigFiles.py
+++ b/ConfigFiles.py
@@ -18,7 +18,27 @@ class ConfigFiles(dict):
             data=self.config[filename]()
             with open(filename, "wt") as h:
                 json.dump(data, h, indent=4)
+        if filename == "hardwarecfg.json":
+            data = self._migrateHardwareSettings(data)
         super(ConfigFiles, self).__init__(data)
+    def _migrateHardwareSettings(self, data):
+        defaults = self.getDefaultHardwareSettings()
+        changed = False
+        for formatName, formatCfg in data.get("filmFormats", {}).items():
+            if "framesPerReelAdvance" not in formatCfg:
+                fpra = defaults["filmFormats"].get(formatName, {}).get("framesPerReelAdvance", 1)
+                formatCfg["framesPerReelAdvance"] = fpra
+                for motor in ("feeder", "pickup"):
+                    if motor in formatCfg and "targetTime" in formatCfg[motor]:
+                        old = formatCfg[motor]["targetTime"]
+                        formatCfg[motor]["targetTime"] = old + (fpra - 1) * old * 30 / 100
+                changed = True
+        if changed:
+            with open(f"_{self.filename}", "wt") as h:
+                json.dump(data, h, sort_keys=True, indent=4)
+            shutil.move(f"_{self.filename}", self.filename)
+        return data
+
     def save(self):
         with open(f"_{self.filename}", "wt") as h:
             json.dump(dict(self), h, sort_keys=True, indent=4)
@@ -83,12 +103,13 @@ class ConfigFiles(dict):
             },
             "filmFormats": {
                 "16mm": {
+                    "framesPerReelAdvance": 3,
                     "feeder": {
                         "faultTreshold": 8000,
                         "ignoreInitial": 10,
                         "speed": 1000.0,
                         "speed2": 100.0,
-                        "targetTime": 0.33
+                        "targetTime": 0.5
                     },
                     "filmdrive": {
                         "faultTreshold": 8000,
@@ -102,16 +123,17 @@ class ConfigFiles(dict):
                         "ignoreInitial": 10,
                         "speed": 2000.0,
                         "speed2": 100.0,
-                        "targetTime": 0.33
+                        "targetTime": 0.5
                     }
                 },
                 "16mmBigReels": {
+                    "framesPerReelAdvance": 3,
                     "feeder": {
                         "faultTreshold": 8000,
                         "ignoreInitial": 10,
                         "speed": 400.0,
                         "speed2": 100.0,
-                        "targetTime": 0.45
+                        "targetTime": 0.7
                     },
                     "filmdrive": {
                         "faultTreshold": 8000,
@@ -125,10 +147,11 @@ class ConfigFiles(dict):
                         "ignoreInitial": 10,
                         "speed": 1000.0,
                         "speed2": 100.0,
-                        "targetTime": 0.45
+                        "targetTime": 0.7
                     }
                 },
                 "35mm": {
+                    "framesPerReelAdvance": 1,
                     "feeder": {
                         "faultTreshold": 8000,
                         "ignoreInitial": 20,
@@ -152,6 +175,7 @@ class ConfigFiles(dict):
                     }
                 },
                 "35mmBigReels": {
+                    "framesPerReelAdvance": 1,
                     "feeder": {
                         "faultTreshold": 8000,
                         "ignoreInitial": 20,
@@ -175,12 +199,13 @@ class ConfigFiles(dict):
                     }
                 },
                 "35mmSoundtrack": {
+                    "framesPerReelAdvance": 6,
                     "feeder": {
                         "faultTreshold": 8000,
                         "ignoreInitial": 20,
                         "speed": 400.0,
                         "speed2": 400.0,
-                        "targetTime": 0.25
+                        "targetTime": 0.7
                     },
                     "filmdrive": {
                         "faultTreshold": 8000,
@@ -194,16 +219,17 @@ class ConfigFiles(dict):
                         "ignoreInitial": 20,
                         "speed": 400.0,
                         "speed2": 400.0,
-                        "targetTime": 0.25
+                        "targetTime": 0.7
                     }
                 },
                 "8mm": {
+                    "framesPerReelAdvance": 6,                    
                     "feeder": {
                         "faultTreshold": 8000,
                         "ignoreInitial": 10,
                         "speed": 800.0,
                         "speed2": 100.0,
-                        "targetTime": 0.33
+                        "targetTime": 0.85
                     },
                     "filmdrive": {
                         "faultTreshold": 8000,
@@ -217,16 +243,17 @@ class ConfigFiles(dict):
                         "ignoreInitial": 10,
                         "speed": 800.0,
                         "speed2": 100.0,
-                        "targetTime": 0.33
+                        "targetTime": 0.85
                     }
                 },
                 "pathex": {
+                    "framesPerReelAdvance": 3,
                     "feeder": {
                         "faultTreshold": 8000,
                         "ignoreInitial": 10,
                         "speed": 800.0,
                         "speed2": 100.0,
-                        "targetTime": 0.33
+                        "targetTime": 0.5
                     },
                     "filmdrive": {
                         "faultTreshold": 8000,
@@ -240,16 +267,17 @@ class ConfigFiles(dict):
                         "ignoreInitial": 10,
                         "speed": 800.0,
                         "speed2": 100.0,
-                        "targetTime": 0.33
+                        "targetTime": 0.5
                     }
                 },
                 "super8": {
+                    "framesPerReelAdvance": 6,
                     "feeder": {
                         "faultTreshold": 8000,
                         "ignoreInitial": 0,
                         "speed": 800.0,
                         "speed2": 100.0,
-                        "targetTime": 0.33
+                        "targetTime": 0.85
                     },
                     "filmdrive": {
                         "faultTreshold": 16000,
@@ -263,7 +291,7 @@ class ConfigFiles(dict):
                         "ignoreInitial": 0,
                         "speed": 800.0,
                         "speed2": 100.0,
-                        "targetTime": 0.33
+                        "targetTime": 0.85
                     }
                 }
             },

--- a/GugusseGUI.py
+++ b/GugusseGUI.py
@@ -109,7 +109,6 @@ class MainWindow(QMainWindow):
 
         threeMotorsLayout=QHBoxLayout()
         self.motors={}
-        self.speedmeters={}
         self.speedEdits={}
         for motor in ["feeder","filmdrive","pickup"]:
             motorSeparatorLayout=QVBoxLayout()
@@ -117,8 +116,6 @@ class MainWindow(QMainWindow):
             label.setAlignment(Qt.AlignCenter)
             label.setStyleSheet("border: 1px solid black;")
             motorSeparatorLayout.addWidget(label)
-            self.speedmeters[motor]=QLabel("peak: ?steps/s")
-            motorSeparatorLayout.addWidget(self.speedmeters[motor])
             threeButtonsLayout=QHBoxLayout()
             trace=False
             if motor == "filmdrive":
@@ -145,8 +142,8 @@ class MainWindow(QMainWindow):
         hlayout = QHBoxLayout()
         self.light_selector = LightControlWidget(self)
         self.econolight = EconolightWidget(self)
-        hlayout.addWidget(self.light_selector.getLabel())
         hlayout.addWidget(self.econolight)
+        hlayout.addWidget(self.light_selector.getLabel())
         hlayout.addWidget(self.light_selector)
         left_layout.addLayout(hlayout)
 

--- a/GugusseGUI.py
+++ b/GugusseGUI.py
@@ -6,7 +6,7 @@ from PyQt5.QtCore import Qt
 from TrinamicSilentMotor import MotorControlWidgets
 
 from GCamera import GCamera
-from Lights import LightControlWidget
+from Lights import LightControlWidget, EconolightWidget
 
 import CameraSettings
 import CaptureSettings
@@ -131,7 +131,9 @@ class MainWindow(QMainWindow):
         self.projectName = CaptureSettings.ProjectNameWidget(self)        
         hlayout = QHBoxLayout()
         self.light_selector = LightControlWidget(self)
+        self.econolight = EconolightWidget(self)
         hlayout.addWidget(self.light_selector.getLabel())
+        hlayout.addWidget(self.econolight)
         hlayout.addWidget(self.light_selector)
         left_layout.addLayout(hlayout)
 

--- a/GugusseGUI.py
+++ b/GugusseGUI.py
@@ -3,7 +3,7 @@ import json
 from PyQt5.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QHBoxLayout, QWidget, QLabel, QSlider, QComboBox, QPushButton, QLineEdit, QTextEdit, QSplitter, QSizePolicy, QWidget, QMessageBox
 from PyQt5.QtCore import Qt
 
-from TrinamicSilentMotor import MotorControlWidgets
+from TrinamicSilentMotor import MotorControlWidgets, MotorSpeedWidget
 
 from GCamera import GCamera
 from Lights import LightControlWidget
@@ -100,10 +100,17 @@ class MainWindow(QMainWindow):
         left_layout.addLayout(hlayout)
 
         self.hwSettings=ConfigFiles("hardwarecfg.json")
-        
+
+        # Created here (ahead of its place in the layout below) so its
+        # currentText() is available to initialize per-motor speeds from
+        # the chosen film format's defaults before the motor widgets exist.
+        self.filmFormat = CaptureSettings.FilmFormatWidget(self)
+        initialFormatCfg=self.hwSettings["filmFormats"][self.filmFormat.currentText()]
+
         threeMotorsLayout=QHBoxLayout()
         self.motors={}
         self.speedmeters={}
+        self.speedEdits={}
         for motor in ["feeder","filmdrive","pickup"]:
             motorSeparatorLayout=QVBoxLayout()
             label=QLabel(motor)
@@ -117,15 +124,21 @@ class MainWindow(QMainWindow):
             if motor == "filmdrive":
                 trace=True
             self.motors[motor]=MotorControlWidgets(self, self.hwSettings[motor], trace=trace)
+            self.motors[motor].motor.setFormat(initialFormatCfg[motor])
+            self.speedEdits[motor]=MotorSpeedWidget(self, self.motors[motor].motor)
+            motorSeparatorLayout.addWidget(self.speedEdits[motor])
             threeButtonsLayout.addWidget(self.motors[motor].ccw)
             threeButtonsLayout.addWidget(self.motors[motor])
             threeButtonsLayout.addWidget(self.motors[motor].cw)
-        
+
             motorSeparatorLayout.addLayout(threeButtonsLayout)
             threeMotorsLayout.addLayout(motorSeparatorLayout)
 
         left_layout.addLayout(threeMotorsLayout)
-        
+
+        self.resetSpeeds=CaptureSettings.ResetSpeedsWidget(self)
+        left_layout.addWidget(self.resetSpeeds)
+
         
         # Project name field
         self.projectName = CaptureSettings.ProjectNameWidget(self)        
@@ -142,7 +155,6 @@ class MainWindow(QMainWindow):
         left_layout.addLayout(hlayout)
 
         #Capture Mode
-        self.filmFormat = CaptureSettings.FilmFormatWidget(self)
         hlayout=QHBoxLayout()
         hlayout.addWidget(self.filmFormat.getLabel())
         hlayout.addWidget(self.filmFormat)
@@ -201,6 +213,9 @@ class MainWindow(QMainWindow):
         self.captureMode.setEnabled(False)
         self.sensors.learn.setEnabled(False)
         self.snapshot.setEnabled(False)
+        self.resetSpeeds.setEnabled(False)
+        for motor in self.speedEdits:
+            self.speedEdits[motor].setEnabled(False)
 
     def reenableWidgetsAfterCapture(self):
         self.light_selector.setEnabled(True)
@@ -209,6 +224,9 @@ class MainWindow(QMainWindow):
         self.captureMode.setEnabled(True)
         self.snapshot.setEnabled(True)
         self.sensors.enableLearnIfPossible()
+        self.resetSpeeds.setEnabled(True)
+        for motor in self.speedEdits:
+            self.speedEdits[motor].setEnabled(True)
         self.motors["feeder"].syncMotorStatus()
         self.motors["filmdrive"].syncMotorStatus()
         self.motors["pickup"].syncMotorStatus()

--- a/Lights.py
+++ b/Lights.py
@@ -67,7 +67,7 @@ class LightControlWidget(QComboBox):
 
 class EconolightWidget(QCheckBox):
     def __init__(self, win):
-        QCheckBox.__init__(self, "econolight")
+        QCheckBox.__init__(self, "ecolight")
         self.win=win
         self.setChecked(True)
 

--- a/Lights.py
+++ b/Lights.py
@@ -5,7 +5,7 @@ from time import sleep
 from json import load
 from sys import argv,exit
 from PyQt5.QtCore import pyqtSignal, Qt
-from PyQt5.QtWidgets import QComboBox, QLabel
+from PyQt5.QtWidgets import QComboBox, QLabel, QCheckBox
 from ConfigFiles import ConfigFiles
 
 GPIO.setwarnings(False)
@@ -63,6 +63,13 @@ class LightControlWidget(QComboBox):
 
     def getLabel(self):
         return self.label
+
+
+class EconolightWidget(QCheckBox):
+    def __init__(self, win):
+        QCheckBox.__init__(self, "econolight")
+        self.win=win
+        self.setChecked(True)
 
 
 if __name__=="__main__":

--- a/TrinamicSilentMotor.py
+++ b/TrinamicSilentMotor.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import RPi.GPIO as GPIO
 GPIO.setmode(GPIO.BCM) 
 from json import dumps, dump
-from PyQt5.QtWidgets import QPushButton
+from PyQt5.QtWidgets import QPushButton, QDoubleSpinBox
 from PyQt5.QtCore import QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QIcon
 
@@ -79,24 +79,32 @@ class TrinamicSilentMotor():
         self.fault=False
         self.shortsInARow=0
         
-    def setFormat(self, cfg):
-        self.speed=cfg["speed"]
-        self.signal.emit(f"spdchg,{self.name},{self.speed}")
+    def setFormat(self, cfg, preserveSpeed=False):
+        if not preserveSpeed:
+            self.speed=cfg["speed"]
+            self.signal.emit(f"spdchg,{self.name},{self.speed}")
         self.speed2=cfg["speed2"]
         self.faultTreshold=cfg["faultTreshold"]
         self.ignoreInitial=cfg["ignoreInitial"]
         self.eighthPoint = self.ignoreInitial / 8.0
         self.sevenEighthPoint = 7.0 * self.ignoreInitial / 8.0
-        
-        
+
+
         self.targetTime=cfg["targetTime"]
         self.eighthTime = self.targetTime / 8.0
-        self.sevenEighthTime = 7.0 * self.targetTime / 8.0 
+        self.sevenEighthTime = 7.0 * self.targetTime / 8.0
 
         if self.isFilmDrive:
             self.halfpoint=self.ignoreInitial / 2
         else:
             self.halfTime=self.targetTime/2
+
+    def setSpeed(self, newSpeed):
+        if newSpeed < self.minSpeed or newSpeed > self.maxSpeed:
+            return False
+        self.speed=newSpeed
+        self.signal.emit(f"spdchg,{self.name},{int(self.speed)}")
+        return True
                 
     def enable(self):
         GPIO.output(self.pinEnable, 0)
@@ -365,6 +373,34 @@ class MotorControlWidgets(QPushButton):
         if msg[0:6]=="spdchg":
             s=msg.split(',')
             self.win.speedmeters[s[1]].setText(f"peak: {s[2]}steps/s")
+            if hasattr(self.win, "speedEdits") and s[1] in self.win.speedEdits:
+                editor=self.win.speedEdits[s[1]]
+                editor.blockSignals(True)
+                editor.setValue(float(s[2]))
+                editor.blockSignals(False)
         else:
             self.win.out.append(msg)
         self.syncMotorStatus()
+
+
+class MotorSpeedWidget(QDoubleSpinBox):
+    def __init__(self, win, motor):
+        QDoubleSpinBox.__init__(self)
+        self.win=win
+        self.motor=motor
+        self.setDecimals(0)
+        self.setRange(motor.minSpeed, motor.maxSpeed)
+        self.setSingleStep(10)
+        self.setValue(motor.speed)
+        self.editingFinished.connect(self.handle)
+
+    def handle(self):
+        value=self.value()
+        if not self.motor.setSpeed(value):
+            self.win.out.append(
+                f"Speed {value} for {self.motor.name} rejected: must be between "
+                f"{self.motor.minSpeed} and {self.motor.maxSpeed}."
+            )
+            self.blockSignals(True)
+            self.setValue(self.motor.speed)
+            self.blockSignals(False)

--- a/TrinamicSilentMotor.py
+++ b/TrinamicSilentMotor.py
@@ -99,6 +99,11 @@ class TrinamicSilentMotor():
         else:
             self.halfTime=self.targetTime/2
 
+    def resetSpeedAdaptation(self):
+        self.histo=[]
+        self.skipHisto=2
+        self.skipAdjust=0
+
     def setSpeed(self, newSpeed):
         if newSpeed < self.minSpeed or newSpeed > self.maxSpeed:
             return False
@@ -372,7 +377,6 @@ class MotorControlWidgets(QPushButton):
     def signalHandle(self, msg):
         if msg[0:6]=="spdchg":
             s=msg.split(',')
-            self.win.speedmeters[s[1]].setText(f"peak: {s[2]}steps/s")
             if hasattr(self.win, "speedEdits") and s[1] in self.win.speedEdits:
                 editor=self.win.speedEdits[s[1]]
                 editor.blockSignals(True)


### PR DESCRIPTION

1. More controls of the speeds at the start of a scan.
2. Now leds are turned off while motors are turning, or more basically we just turn on the leds when they are needed and turn them off, even if for a few seconds, to produce less heat at the end.
3. Multiple frame advances per reel advances (speed optimization)
